### PR TITLE
`TIMSecureStorageError` cases to contain status code from failed operations

### DIFF
--- a/Sources/TIMEncryptedStorage/Extensions/OSStatus+Extensions.swift
+++ b/Sources/TIMEncryptedStorage/Extensions/OSStatus+Extensions.swift
@@ -1,0 +1,18 @@
+import Foundation
+import Security
+
+extension OSStatus {
+
+    /// It would have been preferable to use `CustomStringConvertible`, but `OSStatus` is just an typealias for `Int32`, which already implemented that protocol.
+    var errorDescription: String {
+        let codeString: String = Int(exactly: self)?.description ?? "nil"
+        let codeMessage: String
+        if #available(iOS 11.3, *) {
+            let osStatusString = (SecCopyErrorMessageString(errSecNoStorageModule, nil) as NSString?) as String?
+            codeMessage = osStatusString ?? "-"
+        } else {
+            codeMessage = "- (not available below iOS 11.3)"
+        }
+        return "[\(codeString)]: \(codeMessage)"
+    }
+}

--- a/Sources/TIMEncryptedStorage/Helpers/Test/SecureStorageMock.swift
+++ b/Sources/TIMEncryptedStorage/Helpers/Test/SecureStorageMock.swift
@@ -28,13 +28,13 @@ final class SecureStorageMock : TIMSecureStorage {
             if let data = bioProtectedData[item.id] {
                 return .success(data)
             } else {
-                return .failure(.failedToLoadData(nil))
+                return .failure(.failedToLoadData("No bio protected data available for item: \(item.id)"))
             }
         } else {
             if let data = protectedData[item.id] {
                 return .success(data)
             } else {
-                return .failure(.failedToLoadData(nil))
+                return .failure(.failedToLoadData("No protected data available for item: \(item.id)"))
             }
         }
     }

--- a/Sources/TIMEncryptedStorage/Helpers/Test/SecureStorageMock.swift
+++ b/Sources/TIMEncryptedStorage/Helpers/Test/SecureStorageMock.swift
@@ -28,13 +28,13 @@ final class SecureStorageMock : TIMSecureStorage {
             if let data = bioProtectedData[item.id] {
                 return .success(data)
             } else {
-                return .failure(.failedToLoadData)
+                return .failure(.failedToLoadData(nil))
             }
         } else {
             if let data = protectedData[item.id] {
                 return .success(data)
             } else {
-                return .failure(.failedToLoadData)
+                return .failure(.failedToLoadData(nil))
             }
         }
     }

--- a/Sources/TIMEncryptedStorage/Models/TIMErrorModels.swift
+++ b/Sources/TIMEncryptedStorage/Models/TIMErrorModels.swift
@@ -77,12 +77,16 @@ public enum TIMKeyServiceError: Error, Equatable, LocalizedError {
     }
 }
 
-public enum TIMSecureStorageError : Error, LocalizedError {
+public enum TIMSecureStorageError : Error, LocalizedError, Equatable {
     /// Failed to store data
-    case failedToStoreData
+    /// Parameter is status code responding to the SecureStorage implementation that is used.
+    /// `TIMKeychain` will report `OSStatus` values.
+    case failedToStoreData(Int?)
 
     /// Failed to load data
-    case failedToLoadData
+    /// Parameter is status code responding to the SecureStorage implementation that is used.
+    /// `TIMKeychain` will report `OSStatus` values.
+    case failedToLoadData(Int?)
 
     /// Authentication failed for data retrieve (e.g. TouchID/FaceID)
     case authenticationFailedForData
@@ -91,10 +95,10 @@ public enum TIMSecureStorageError : Error, LocalizedError {
         switch self {
         case .authenticationFailedForData:
             return "The authentication failed for data, e.g. the user failed to unlock or cancelled the biometric ID prompt."
-        case .failedToLoadData:
-            return "Failed to load data from secure storage."
-        case .failedToStoreData:
-            return "Failed to store data in secure storage."
+        case .failedToLoadData(let status):
+            return "Failed to load data from secure storage [\(status?.description ?? "nil")]."
+        case .failedToStoreData(let status):
+            return "Failed to store data in secure storage [\(status?.description ?? "nil")]."
         }
     }
 }

--- a/Sources/TIMEncryptedStorage/Models/TIMErrorModels.swift
+++ b/Sources/TIMEncryptedStorage/Models/TIMErrorModels.swift
@@ -79,14 +79,14 @@ public enum TIMKeyServiceError: Error, Equatable, LocalizedError {
 
 public enum TIMSecureStorageError : Error, LocalizedError, Equatable {
     /// Failed to store data
-    /// Parameter is status code responding to the SecureStorage implementation that is used.
-    /// `TIMKeychain` will report `OSStatus` values.
-    case failedToStoreData(Int?)
+    /// Parameter is custom error message from SecureStorage implementation that is used.
+    /// `TIMKeychain` will report `OSStatus` descriptions.
+    case failedToStoreData(String)
 
     /// Failed to load data
-    /// Parameter is status code responding to the SecureStorage implementation that is used.
-    /// `TIMKeychain` will report `OSStatus` values.
-    case failedToLoadData(Int?)
+    /// Parameter is custom error message from SecureStorage implementation that is used.
+    /// `TIMKeychain` will report `OSStatus` descriptions.
+    case failedToLoadData(String)
 
     /// Authentication failed for data retrieve (e.g. TouchID/FaceID)
     case authenticationFailedForData
@@ -95,10 +95,10 @@ public enum TIMSecureStorageError : Error, LocalizedError, Equatable {
         switch self {
         case .authenticationFailedForData:
             return "The authentication failed for data, e.g. the user failed to unlock or cancelled the biometric ID prompt."
-        case .failedToLoadData(let status):
-            return "Failed to load data from secure storage [\(status?.description ?? "nil")]."
-        case .failedToStoreData(let status):
-            return "Failed to store data in secure storage [\(status?.description ?? "nil")]."
+        case .failedToLoadData(let message):
+            return "Failed to load data from secure storage [\(message)]."
+        case .failedToStoreData(let message):
+            return "Failed to store data in secure storage [\(message)]."
         }
     }
 }

--- a/Sources/TIMEncryptedStorage/TIM/Keychain/TIMKeychain.swift
+++ b/Sources/TIMEncryptedStorage/TIM/Keychain/TIMKeychain.swift
@@ -43,7 +43,7 @@ public final class TIMKeychain : TIMSecureStorage {
             mutableItem.enableSafeAccessControl(safeAccessControl)
             result = store(data: data, item: mutableItem)
         } else {
-            result = .failure(.failedToStoreData)
+            result = .failure(.failedToStoreData(nil))
         }
         return result
     }
@@ -91,7 +91,7 @@ public final class TIMKeychain : TIMSecureStorage {
         case noErr:
             result = .success(Void())
         default:
-            result = .failure(.failedToStoreData)
+            result = .failure(.failedToStoreData(Int(status)))
         }
         return result
     }
@@ -105,10 +105,10 @@ public final class TIMKeychain : TIMSecureStorage {
             if let optData = (data as? Data) {
                 result = .success(optData)
             } else {
-                result = .failure(.failedToLoadData)
+                result = .failure(.failedToLoadData(Int(status)))
             }
         default:
-            result = .failure(.failedToLoadData)
+            result = .failure(.failedToLoadData(Int(status)))
         }
         return result
     }

--- a/Sources/TIMEncryptedStorage/TIM/Keychain/TIMKeychain.swift
+++ b/Sources/TIMEncryptedStorage/TIM/Keychain/TIMKeychain.swift
@@ -43,7 +43,7 @@ public final class TIMKeychain : TIMSecureStorage {
             mutableItem.enableSafeAccessControl(safeAccessControl)
             result = store(data: data, item: mutableItem)
         } else {
-            result = .failure(.failedToStoreData(nil))
+            result = .failure(.failedToStoreData("Failed to generate SecAccessControl object for data."))
         }
         return result
     }
@@ -91,7 +91,7 @@ public final class TIMKeychain : TIMSecureStorage {
         case noErr:
             result = .success(Void())
         default:
-            result = .failure(.failedToStoreData(Int(status)))
+            result = .failure(.failedToStoreData(status.errorDescription))
         }
         return result
     }
@@ -105,10 +105,10 @@ public final class TIMKeychain : TIMSecureStorage {
             if let optData = (data as? Data) {
                 result = .success(optData)
             } else {
-                result = .failure(.failedToLoadData(Int(status)))
+                result = .failure(.failedToLoadData(status.errorDescription))
             }
         default:
-            result = .failure(.failedToLoadData(Int(status)))
+            result = .failure(.failedToLoadData(status.errorDescription))
         }
         return result
     }

--- a/Tests/TIMEncryptedStorageTests/KeychainStoreItemTests.swift
+++ b/Tests/TIMEncryptedStorageTests/KeychainStoreItemTests.swift
@@ -40,7 +40,7 @@ final class KeychainStoreItemTests: XCTestCase {
         assertResult(result2, expectedDataType: nil, expectedError: .authenticationFailedForData)
 
         let result3 = keychain.mapStoreStatusToResult(errSecDeviceFailed)
-        assertResult(result3, expectedDataType: nil, expectedError: .failedToStoreData(Int(errSecDeviceFailed)))
+        assertResult(result3, expectedDataType: nil, expectedError: .failedToStoreData(errSecDeviceFailed.errorDescription))
     }
 
     func testLoadStatusMapping() {
@@ -51,7 +51,7 @@ final class KeychainStoreItemTests: XCTestCase {
         assertResult(result2, expectedDataType: nil, expectedError: .authenticationFailedForData)
 
         let result3 = keychain.mapLoadStatusToResult(errSecDeviceFailed, data: nil)
-        assertResult(result3, expectedDataType: nil, expectedError: .failedToLoadData(Int(errSecDeviceFailed)))
+        assertResult(result3, expectedDataType: nil, expectedError: .failedToLoadData(errSecDeviceFailed.errorDescription))
     }
 
     private func assertResult<T>(_ result: Result<T, TIMSecureStorageError>, expectedDataType: T.Type?, expectedError: TIMSecureStorageError?) {

--- a/Tests/TIMEncryptedStorageTests/KeychainStoreItemTests.swift
+++ b/Tests/TIMEncryptedStorageTests/KeychainStoreItemTests.swift
@@ -40,7 +40,7 @@ final class KeychainStoreItemTests: XCTestCase {
         assertResult(result2, expectedDataType: nil, expectedError: .authenticationFailedForData)
 
         let result3 = keychain.mapStoreStatusToResult(errSecDeviceFailed)
-        assertResult(result3, expectedDataType: nil, expectedError: .failedToStoreData)
+        assertResult(result3, expectedDataType: nil, expectedError: .failedToStoreData(Int(errSecDeviceFailed)))
     }
 
     func testLoadStatusMapping() {
@@ -51,7 +51,7 @@ final class KeychainStoreItemTests: XCTestCase {
         assertResult(result2, expectedDataType: nil, expectedError: .authenticationFailedForData)
 
         let result3 = keychain.mapLoadStatusToResult(errSecDeviceFailed, data: nil)
-        assertResult(result3, expectedDataType: nil, expectedError: .failedToLoadData)
+        assertResult(result3, expectedDataType: nil, expectedError: .failedToLoadData(Int(errSecDeviceFailed)))
     }
 
     private func assertResult<T>(_ result: Result<T, TIMSecureStorageError>, expectedDataType: T.Type?, expectedError: TIMSecureStorageError?) {

--- a/Tests/TIMEncryptedStorageTests/OSStatusExtensionsTests.swift
+++ b/Tests/TIMEncryptedStorageTests/OSStatusExtensionsTests.swift
@@ -1,0 +1,11 @@
+@testable import TIMEncryptedStorage
+import XCTest
+import Security
+
+final class OSStatusExtensionsTests: XCTestCase {
+    func testErrorDescription() {
+        let status: OSStatus = errSecCreateChainFailed
+        let expectedString = "[-25318]: A required component (data storage module) could not be loaded. You may need to restart your computer."
+        XCTAssertEqual(expectedString, status.errorDescription)
+    }
+}


### PR DESCRIPTION
Failed `OSStatus` can be A LOT of different things, and we are seeing rare cases of decryption operations that fails, but we have no idea what is wrong. This will make it easier to debug such errors.