### PR TITLE
Reinitialising URLSession on non-http-errors, before throwing an error

### DIFF
--- a/Sources/TIMEncryptedStorage/TIM/Keychain/TIMKeychainStoreItem.swift
+++ b/Sources/TIMEncryptedStorage/TIM/Keychain/TIMKeychainStoreItem.swift
@@ -5,7 +5,7 @@ import Foundation
 public struct TIMKeychainStorageItem: TIMSecureStorageItem {
 
     public let id: String
-    private (set) var parameters: [String: Any]
+    private(set) var parameters: [String: Any]
 
     public init(id: String) {
         self.id = id


### PR DESCRIPTION
For a long time we have had some strange errors when trying to login in the Compassana app. I pinpointed it to this call, where it looks like the URLSession throws an error without actually going any outbound calls. It simply throws a "no internet"-error. This lead me to think that the URLSession is broken or stuck. Restarting the app will fix the issue.

I'll try and run with this change for a bit, to see if the issue still persists. If it works, I'll assign someone to review the PR. For now it's just a draft :)